### PR TITLE
Fix subsequent backup after failed backup

### DIFF
--- a/common/tree.js
+++ b/common/tree.js
@@ -306,9 +306,8 @@ export class Tree {
     function onStarted (id) { downloadId = id; }
     function progress (delta) {
       //debug('Download delta', delta);
-      if ((delta.id === downloadId)
-        && delta.state && delta.state.current === "complete")
-      {
+      if (delta.id !== downloadId) return;
+      if (delta.state?.current === "complete") {
         //log(`Download succeeded: ${filename}`);
         api.downloads.onChanged.removeListener(progress);
         api.storage.local.set({ localBackupLastTimeCompleted: Date.now() });
@@ -323,6 +322,8 @@ export class Tree {
           URL.revokeObjectURL(url);
         } catch (err) {
         }
+      } else if (!!delta.error?.current || delta.state?.current === "interrupted") {
+        onFailed.call(this, delta.error?.current || 'Download was interrupted');
       }
     }
     function onFailed (err) {
@@ -331,7 +332,7 @@ export class Tree {
       this.localBackupInProgress = false;
     }
     api.downloads.onChanged.addListener(progress.bind(this));
-    downloading.then(onStarted, onFailed);
+    downloading.then(onStarted, onFailed.bind(this));
   }
 
   getNodeByTabId (tabId, root)  {

--- a/common/tree.js
+++ b/common/tree.js
@@ -303,13 +303,13 @@ export class Tree {
       saveAs: false
     });
     let downloadId;
-    function onStarted (id) { downloadId = id; }
-    function progress (delta) {
+    const onStarted = (id) => downloadId = id;
+    const onProgress = (delta) => {
       //debug('Download delta', delta);
       if (delta.id !== downloadId) return;
       if (delta.state?.current === "complete") {
         //log(`Download succeeded: ${filename}`);
-        api.downloads.onChanged.removeListener(progress);
+        api.downloads.onChanged.removeListener(onProgress);
         api.storage.local.set({ localBackupLastTimeCompleted: Date.now() });
         this.localBackupInProgress = false;
         if (this.setStatus) {
@@ -323,16 +323,16 @@ export class Tree {
         } catch (err) {
         }
       } else if (!!delta.error?.current || delta.state?.current === "interrupted") {
-        onFailed.call(this, delta.error?.current || 'Download was interrupted');
+        onFailed(delta.error?.current || 'Download was interrupted');
       }
-    }
-    function onFailed (err) {
+    };
+    const onFailed = (err) => {
       warn(`Download failed: ${err}`);
-      api.downloads.onChanged.removeListener(progress);
+      api.downloads.onChanged.removeListener(onProgress);
       this.localBackupInProgress = false;
-    }
-    api.downloads.onChanged.addListener(progress.bind(this));
-    downloading.then(onStarted, onFailed.bind(this));
+    };
+    api.downloads.onChanged.addListener(onProgress);
+    downloading.then(onStarted, onFailed);
   }
 
   getNodeByTabId (tabId, root)  {


### PR DESCRIPTION
Previously, the `localBackupInProgress` flag was not correctly cleared when the download of a backup failed, preventing also future attempts of backing up. The issue existed for both, for downloads failing to start and downloads failing after they started.
It has been especially observed when the browser is configured to not automatically download files to the Downloads folder, but instead to ask the user where to save the file, at which stage, the download can still be cancelled, which before this change was not correctly detected.

Additionally, this PR fixes registered progress event listeners not correctly being cleared.

Some more details in the commit messages.

Please, note that I only tested in Ungoogled Chromium.