### PR TITLE
Add "flatten" action to the sidebar, with undo support

### DIFF
--- a/common/node.js
+++ b/common/node.js
@@ -182,9 +182,18 @@ export class Node {
   }
 
   isFlattenable () {
-    // true if there are descendants nested deeper than direct children
-    // (we don't flatten the contents of nested windows, so ignore those)
+    // flatten is offered on any node that has children, at every level of
+    // the tree.  Nodes with grand-children collapse their subtree inward;
+    // nodes whose children are already flat lift those children up to
+    // become siblings of this node (see flatten()).
     if (this.isRoot()) return false;
+    return this.hasKids();
+  }
+
+  hasGrandKids () {
+    // true if any (non-window) child has children of its own, i.e. there's
+    // something nested deeper than a single flat level below this node.
+    // (nested windows don't count; their tabs stay inside their own window)
     for (const kid of this.nodes) {
       if (kid.isWindow()) continue;
       if (kid.hasKids()) return true;
@@ -195,24 +204,49 @@ export class Node {
   async flatten (args) {
     debug('Node.flatten()');
     if (! args) { error(`Node.flatten(): no args`); return null; }
-    if (this.isRoot()) return null;
-    // collect all descendants in pre-order, but don't reach into nested
-    // windows (their loaded tabs have to stay inside their own window)
-    const descendants = this.findNodes(null, (n) => ! n.isWindow());
-    if (descendants.length <= 0) return null;
-    // remember where everything started, so this can be undone later
-    const original = descendants.map((node) => ({
+    if (this.isRoot() || (! this.hasKids())) return null;
+
+    if (this.hasGrandKids()) {
+      // children are nested deeper than one level: collapse the whole
+      // subtree into this node, keeping pre-order.  (don't reach into
+      // nested windows; their loaded tabs have to stay in their window)
+      const descendants = this.findNodes(null, (n) => ! n.isWindow());
+      if (descendants.length <= 0) return null;
+      // remember where everything started, so this can be undone later
+      const original = descendants.map((node) => ({
+        nodeId: node.id,
+        parentId: node.parent.id,
+        index: node.indexOf(),
+      }));
+      // move every descendant up to be a direct child of this node,
+      // keeping their original (pre-order) visual order intact
+      let moved = 0;
+      for (let i = 0; i < descendants.length; i++) {
+        if (await descendants[i].moveTo(this, i, args)) moved ++;
+      }
+      debug(`flatten(collapsed ${moved} / ${descendants.length} descendants)`);
+      if (moved <= 0) return null;
+      return original;
+    }
+
+    // children are already a single flat level: lift them up to become
+    // siblings of this node (children of this node's parent)
+    const parent = this.parent;
+    if (! parent) return null;
+    const kids = [...this.nodes];
+    // capture original positions (all still under this node right now)
+    const original = kids.map((node) => ({
       nodeId: node.id,
-      parentId: node.parent.id,
+      parentId: this.id,
       index: node.indexOf(),
     }));
-    // move every descendant up to be a direct child of this node,
-    // keeping their original (pre-order) visual order intact
+    // move each child to just after this node, preserving order
+    // (this node doesn't move, so its index stays put as kids leave)
     let moved = 0;
-    for (let i = 0; i < descendants.length; i++) {
-      if (await descendants[i].moveTo(this, i, args)) moved ++;
+    for (let i = 0; i < kids.length; i++) {
+      if (await kids[i].moveTo(parent, this.indexOf() + 1 + i, args)) moved ++;
     }
-    debug(`flatten(moved ${moved} / ${descendants.length} descendants)`);
+    debug(`flatten(promoted ${moved} / ${kids.length} kids)`);
     if (moved <= 0) return null;
     return original;
   }

--- a/common/node.js
+++ b/common/node.js
@@ -181,6 +181,58 @@ export class Node {
     return false;
   }
 
+  isFlattenable () {
+    // true if there are descendants nested deeper than direct children
+    // (we don't flatten the contents of nested windows, so ignore those)
+    if (this.isRoot()) return false;
+    for (const kid of this.nodes) {
+      if (kid.isWindow()) continue;
+      if (kid.hasKids()) return true;
+    }
+    return false;
+  }
+
+  async flatten (args) {
+    debug('Node.flatten()');
+    if (! args) { error(`Node.flatten(): no args`); return null; }
+    if (this.isRoot()) return null;
+    // collect all descendants in pre-order, but don't reach into nested
+    // windows (their loaded tabs have to stay inside their own window)
+    const descendants = this.findNodes(null, (n) => ! n.isWindow());
+    if (descendants.length <= 0) return null;
+    // remember where everything started, so this can be undone later
+    const original = descendants.map((node) => ({
+      nodeId: node.id,
+      parentId: node.parent.id,
+      index: node.indexOf(),
+    }));
+    // move every descendant up to be a direct child of this node,
+    // keeping their original (pre-order) visual order intact
+    let moved = 0;
+    for (let i = 0; i < descendants.length; i++) {
+      if (await descendants[i].moveTo(this, i, args)) moved ++;
+    }
+    debug(`flatten(moved ${moved} / ${descendants.length} descendants)`);
+    if (moved <= 0) return null;
+    return original;
+  }
+
+  async restoreFlatten (original, args) {
+    // undo a flatten() by moving each node back to where it started;
+    // 'original' is in pre-order, so parents are restored before their
+    // kids and the tree rebuilds itself level by level
+    debug('Node.restoreFlatten()');
+    if (! original) return false;
+    let moved = 0;
+    for (const rec of original) {
+      const node = this.tree.nodes[rec.nodeId];
+      const parent = this.tree.nodes[rec.parentId];
+      if ((! node) || (! parent)) continue;
+      if (await node.moveTo(parent, rec.index, args)) moved ++;
+    }
+    return (moved > 0);
+  }
+
   indexOf () {
     if (!this.parent) return 0;
     if (!this.parent.nodes) return 0;

--- a/themes/tk.css
+++ b/themes/tk.css
@@ -922,6 +922,10 @@ foo {
   color: var(--marked-count-color);
 }
 
+#hover-menu .flatten-button, .flatten-button {
+  color: var(--label-loaded-fg);
+}
+
 /******************** drag-n-drop ********************/
 
 .dragging {

--- a/themes/tk.css
+++ b/themes/tk.css
@@ -942,6 +942,15 @@ foo {
 #hover-menu .flatten-button, .flatten-button {
   color: var(--label-loaded-fg);
 }
+/* flatten button color encodes which action it will perform */
+#hover-menu .flatten-button.flatten-collapse, .flatten-button.flatten-collapse {
+  /* green: collapse this node's whole subtree inward */
+  color: #3ad13a;
+}
+#hover-menu .flatten-button.flatten-hoist, .flatten-button.flatten-hoist {
+  /* magenta: hoist a lone flat level up to become siblings */
+  color: #e25be2;
+}
 
 /******************** drag-n-drop ********************/
 

--- a/themes/tk.css
+++ b/themes/tk.css
@@ -605,10 +605,12 @@ foo {
 #tree-view .collapsed .node-stats {
   display: unset;
 }
-/* ...but a single-child node is flattened (its lone child is shown as a
+/* ...but a single-child *tab* is flattened (its lone child is shown as a
  * sibling), so its own tab counter is redundant -- hide it.  (needs the
- * #tree-view id to outrank the ".collapsed .node-stats" rule above) */
-#tree-view .node:has(> .nodes:not(.root-nodes) > .node:only-child) > .row .node-stats {
+ * #tree-view id to outrank the ".collapsed .node-stats" rule above)
+ * non-tab nodes (windows, headings, ...) keep their counter and follow the
+ * normal collapsed/config visibility rules above. */
+#tree-view .node.tab:has(> .nodes:not(.root-nodes) > .node:only-child) > .row .node-stats {
   display: none;
 }
 

--- a/themes/tk.css
+++ b/themes/tk.css
@@ -338,6 +338,17 @@ foo {
   border-left: 2px solid var(--tree-line-cursor);
 }
 
+/* single-child flattening:
+ * if a node has exactly one child, display that child as a sibling --
+ * drop the indentation of its (one-item) child list so the lone child
+ * lines up with its parent's row instead of nesting beneath it.
+ * (chains of single children all collapse onto the same level) */
+.nodes:not(.root-nodes):has(> .node:only-child) {
+  margin-left: 0;
+  padding-left: 0;
+  border-left: 0;
+}
+
 /* outer structure...
  * #tree-root.nodes.root-nodes
  *   #noderoot.node.root-nodes
@@ -593,6 +604,12 @@ foo {
 }
 #tree-view .collapsed .node-stats {
   display: unset;
+}
+/* ...but a single-child node is flattened (its lone child is shown as a
+ * sibling), so its own tab counter is redundant -- hide it.  (needs the
+ * #tree-view id to outrank the ".collapsed .node-stats" rule above) */
+#tree-view .node:has(> .nodes:not(.root-nodes) > .node:only-child) > .row .node-stats {
+  display: none;
 }
 
 .node-stats {

--- a/view/nodeview.js
+++ b/view/nodeview.js
@@ -85,6 +85,16 @@ export class NodeView extends Node {
       this.$row.classList.remove('window');
     }
 
+    // are we a tab? (vs a window, heading, or other non-tab node)
+    if (this.isTab()) {
+      this.$.classList.add('tab');
+      this.$row.classList.add('tab');
+    }
+    else {
+      this.$.classList.remove('tab');
+      this.$row.classList.remove('tab');
+    }
+
     // if the details box is showing this node, update it
     if (this.isCursor()) {
       this.$renderDetails(this.tree.$detailsBox);

--- a/view/treeview.js
+++ b/view/treeview.js
@@ -51,6 +51,9 @@ export class TreeView extends Tree {
 
     // { nodeId: node, ... }
     this.expandOverrides = {};
+
+    // stack of { label, undo: async fn } entries for undoable actions
+    this.undoStack = [];
   }
 
   destroy () {
@@ -112,6 +115,9 @@ export class TreeView extends Tree {
     this.$donateBtn = doc.getElementById('donate-btn');
     // open the extension's help page
     this.$helpBtn = doc.getElementById('help-btn');
+
+    // undo button (currently used by the "flatten" action)
+    this.$undoBtn = doc.getElementById('undo-btn');
 
     // count of marked nodes when non-zero
     this.$markedCount = doc.getElementById('marked-count');
@@ -2187,6 +2193,9 @@ export class TreeView extends Tree {
     if (! this.$hoverMenuMark) {
       this.$hoverMenuMark = makeBtn(this, 'mark-button', 'M', 'toggleMarked');
     }
+    if (! this.$hoverMenuFlatten) {
+      this.$hoverMenuFlatten = makeBtn(this, 'flatten-button', 'F', 'flattenNode');
+    }
     if (! this.$hoverMenuDelete) {
       this.$hoverMenuDelete = makeBtn(this, 'delete-button', 'D', 'deleteNode');
     }
@@ -2245,6 +2254,11 @@ export class TreeView extends Tree {
     if (mouseNode.isMarkable())
       this.$hoverMenuMark.style.display = 'inline-block';
     else this.$hoverMenuMark.style.display = 'none';
+
+    // show or hide the 'flatten' button
+    if (mouseNode.isFlattenable())
+      this.$hoverMenuFlatten.style.display = 'inline-block';
+    else this.$hoverMenuFlatten.style.display = 'none';
 
     // show or hide the 'delete' button
     if (mouseNode.isDeletable())
@@ -2560,6 +2574,12 @@ export class TreeView extends Tree {
     this.$treeViewInTabBtn.addEventListener('click', () => {
       this.onTreeViewInTabBtnClick();
     });
+    // undo the most recent undoable action
+    if (this.$undoBtn) {
+      this.$undoBtn.addEventListener('click', () => {
+        this.onUndoBtnClick();
+      });
+    }
     // zoom in and out
     this.$zoomOutBtn.addEventListener('click', () => {
       this.onZoomBtn(-1);
@@ -2616,6 +2636,69 @@ export class TreeView extends Tree {
     const label = this.viewScope.charAt(0).toUpperCase()
       + this.viewScope.slice(1);
     this.$viewScopeBtn.innerText = label;
+  }
+
+  // ---- undo support ----------------------------------------------------
+
+  pushUndo (entry) {
+    // entry: { label, undo: async () => {...} }
+    this.undoStack.push(entry);
+    this.$renderUndoBtn();
+  }
+
+  $renderUndoBtn () {
+    if (! this.$undoBtn) return;
+    if (this.undoStack.length > 0)
+      this.$undoBtn.classList.remove('greyed-out');
+    else
+      this.$undoBtn.classList.add('greyed-out');
+  }
+
+  async onUndoBtnClick () {
+    return this.action_undo({ type: 'click' });
+  }
+
+  async action_undo (event) {
+    const entry = this.undoStack.pop();
+    this.$renderUndoBtn();
+    if (! entry) {
+      this.setStatus('nothing to undo');
+      return;
+    }
+    await entry.undo();
+    this.setStatus(`undid: ${entry.label}`);
+  }
+
+  async action_flattenNode (event) {
+    debug('flattenNode');
+    // choose mouse or keyboard cursor based on event type
+    let cursor = this.whichCursor(event);
+    // skip no-op cases
+    if (! cursor) return;
+    if (! cursor.isFlattenable()) {
+      this.setStatus('nothing to flatten');
+      return;
+    }
+
+    // move keyboard cursor if this was a mouse click
+    if (cursor !== this.cursor) await this.setCursor(cursor);
+
+    const line = cursor.toLine();
+    const target = cursor;
+    // flatten() returns the data needed to put everything back
+    const original = await target.flatten({ reason: 'userAction' });
+    if (! original) {
+      this.setStatus('nothing to flatten');
+      return;
+    }
+    // make the action undoable
+    this.pushUndo({
+      label: `flatten ${line}`,
+      undo: async () => {
+        await target.restoreFlatten(original, { reason: 'userAction' });
+      },
+    });
+    this.setStatus(`flattened ${original.length} nodes under ${line}`);
   }
 
   action_detailsButton (event) {

--- a/view/treeview.js
+++ b/view/treeview.js
@@ -2255,9 +2255,19 @@ export class TreeView extends Tree {
       this.$hoverMenuMark.style.display = 'inline-block';
     else this.$hoverMenuMark.style.display = 'none';
 
-    // show or hide the 'flatten' button
-    if (mouseNode.isFlattenable())
+    // show or hide the 'flatten' button, and color it by what it'll do:
+    // green ('flatten-collapse') = collapse this node's subtree inward,
+    // magenta ('flatten-hoist') = hoist a lone flat level up to siblings
+    if (mouseNode.isFlattenable()) {
       this.$hoverMenuFlatten.style.display = 'inline-block';
+      if (mouseNode.hasGrandKids()) {
+        this.$hoverMenuFlatten.classList.add('flatten-collapse');
+        this.$hoverMenuFlatten.classList.remove('flatten-hoist');
+      } else {
+        this.$hoverMenuFlatten.classList.add('flatten-hoist');
+        this.$hoverMenuFlatten.classList.remove('flatten-collapse');
+      }
+    }
     else this.$hoverMenuFlatten.style.display = 'none';
 
     // show or hide the 'delete' button


### PR DESCRIPTION
Flatten moves every descendant of a node up to be a direct child of that node, collapsing the subtree to a single level while preserving the original (pre-order) visual order.  Nested windows are left intact, since their loaded tabs must stay inside their own window.

- Node.isFlattenable() / Node.flatten() / Node.restoreFlatten() implement the move and capture enough state to reverse it.
- TreeView gains a small undo stack; the previously-inert "Undo" toolbar button is now wired up and flatten pushes an undo entry onto it.
- A new "F" button appears in the row hover menu for nodes that have something to flatten.