### PR TITLE
Improve window and tab focus handling in tree navigation

### DIFF
--- a/common/node.js
+++ b/common/node.js
@@ -1698,6 +1698,20 @@ export class Node {
     return true;
   }
 
+  async focusWindow (args) {
+    // bring this (loaded) browser window to the foreground
+    if (! this.isWindow()) return false;
+    if (! this.isLoaded()) return false;
+    if (! this.windowId) return false;
+    try {
+      await api.windows.update(this.windowId, { focused: true });
+    } catch (e) {
+      warn(`Node.focusWindow(): can't focus window ${this.windowId}`, e);
+      return false;
+    }
+    return true;
+  }
+
   getActiveTab () {
     const nodes = this.findNodes(
       function (node) { return node.isActive() && node.isLoaded(); },

--- a/view/treeview.js
+++ b/view/treeview.js
@@ -1507,12 +1507,21 @@ export class TreeView extends Tree {
       cursor.load({ reason: 'userAction' });
       this.setStatus(`loaded ${cursor.toLine()}`);
     }
-    // if loaded tab but not focused, focus it
-    else if (cursor.isLoaded()
-      && (!cursor.isActive())
-      && (!cursor.isWindow())
-    ) {
-      cursor.setActive(true, { reason: 'userAction' });
+    // if loaded tab that isn't already the active tab of the focused
+    // window, switch to it: activate the tab and raise its window.
+    // (activating a tab alone doesn't bring its window to the foreground,
+    //  so a tab in another window needs an explicit window focus too)
+    else if (cursor.isLoadedTab()) {
+      const windowNode = cursor.getWindowNode(true);
+      const windowFocused = !! (windowNode && windowNode.isActive());
+      if ((! cursor.isActive()) || (! windowFocused)) {
+        if (! cursor.isActive())
+          await cursor.setActive(true, { reason: 'userAction' });
+        if (windowNode) await windowNode.focusWindow({ reason: 'userAction' });
+        this.setStatus(`focused ${cursor.toLine()}`);
+      }
+      // already the active tab of the focused window -> edit it
+      else if (allowEdit) this.action_editNode(event);
     }
     // if loaded window other than the focused one, switch to / focus it
     else if (cursor.isWindow()

--- a/view/treeview.js
+++ b/view/treeview.js
@@ -1514,6 +1514,15 @@ export class TreeView extends Tree {
     ) {
       cursor.setActive(true, { reason: 'userAction' });
     }
+    // if loaded window other than the focused one, switch to / focus it
+    else if (cursor.isWindow()
+      && cursor.isLoaded()
+      && (! cursor.isActive())
+    ) {
+      const ok = await cursor.focusWindow({ reason: 'userAction' });
+      if (ok) this.setStatus(`focused ${cursor.toLine()}`);
+      else this.setStatus(`failed to focus ${cursor.toLine()}`);
+    }
     // if unloaded window, load it
     else if (cursor.isUnloadedWindow()) {
       cursor.load({ reason: 'userAction' });


### PR DESCRIPTION
## Summary
Enhanced the tree view navigation logic to properly handle focusing tabs and windows, ensuring that activating a tab also brings its parent window to the foreground when necessary.

## Key Changes
- **Refactored tab focus logic**: When navigating to a loaded tab, the code now checks if the tab's window is focused. If not, it activates the tab and explicitly focuses its window to bring it to the foreground.
- **Added `focusWindow()` method**: New async method in `Node` class that brings a loaded browser window to the foreground using the WebExtensions API.
- **Improved window focus handling**: Separated logic for focusing windows from tab activation, with proper error handling and status messages.
- **Better condition checking**: Replaced simple `isActive()` check with more comprehensive logic that verifies both tab activation and window focus state.

## Implementation Details
- The tab focus path now uses `cursor.isLoadedTab()` to identify loaded tabs and checks `windowNode.isActive()` to determine if the parent window is focused.
- If a tab is already active and its window is focused, the edit action is triggered instead of redundant focus operations.
- Window focus operations include try-catch error handling and return boolean status for caller feedback.
- Status messages now distinguish between "focused" and "failed to focus" outcomes.

https://claude.ai/code/session_019TubuU9gXcwJnqDDoSuwhG